### PR TITLE
Match double digit version numbers

### DIFF
--- a/get_latest_version_download_file.sh
+++ b/get_latest_version_download_file.sh
@@ -2,7 +2,7 @@
 # 2014-01-29
 # Find the latest version and download file link from the OpenCV sourceforge page
 
-version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o '\"[0-9](\.[0-9])+' | cut -c2-)"
+version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o '\"[0-9](\.[0-9]+)+' | cut -c2-)"
 downloadfilelist="opencv-$version.tar.gz opencv-$version.zip"
 downloadfile=
 for file in $downloadfilelist;


### PR DESCRIPTION
This patch match 2.4.10 version numbers. Correctly download OpenCV 2.4.10 double digit version numbers 
