### PR TITLE
Handle release candidates.

### DIFF
--- a/get_latest_version_download_file.sh
+++ b/get_latest_version_download_file.sh
@@ -2,7 +2,7 @@
 # 2014-01-29
 # Find the latest version and download file link from the OpenCV sourceforge page
 
-version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o '\"[0-9](\.[0-9]+)+' | cut -c2-)"
+version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o '\"[0-9](\.[0-9]+)+(-[-a-zA-Z0-9]+)?' | cut -c2-)"
 downloadfilelist="opencv-$version.tar.gz opencv-$version.zip"
 downloadfile=
 for file in $downloadfilelist;


### PR DESCRIPTION
I couldn't install this on Ubuntu today because the latest version is 3.0.0-rc1, but this script only matched 3.0.0. So, it 404'd. Updated the regex to handle release candidates/betas/etc... 