### PR TITLE
Missing interpreter on first line comment

### DIFF
--- a/Ubuntu/opencv_latest.sh
+++ b/Ubuntu/opencv_latest.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 . `dirname $0`/../get_latest_version_download_file.sh
 if [ $? -ne 0 ]; then
     exit $?;


### PR DESCRIPTION
By default it tries to run with sh and fails.