### PR TITLE
Added -c (continue flag) to wget

### DIFF
--- a/Ubuntu/opencv_install.sh
+++ b/Ubuntu/opencv_install.sh
@@ -30,7 +30,7 @@ source dependencies.sh
 echo "--- Downloading OpenCV" $version
 mkdir -p $dldir
 cd $dldir
-wget -O $downloadfile http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/$version/$downloadfile/download
+wget -c -O $downloadfile http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/$version/$downloadfile/download
 
 echo "--- Installing OpenCV" $version
 echo $downloadfile | grep ".zip"


### PR DESCRIPTION
If someone has already downloaded the opencv source zip, they can just place it inside `OpenCV` directory and `wget` wont bother downloading it from scratch again. Or if the download breaks midway, `-c` can take it up from where it broke.