### PR TITLE
Fixed syntax issue in script for OpenCV 2.4.10 on Ubuntu

### DIFF
--- a/Ubuntu/2.4/opencv2_4_10.sh
+++ b/Ubuntu/2.4/opencv2_4_10.sh
@@ -25,7 +25,7 @@ if ! [ -f "OpenCV-2.4.10.zip" ]; then
   wget -O OpenCV-2.4.10.zip http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.4.10/opencv-2.4.10.zip/download
 fi
 echo "Installing OpenCV 2.4.10"
-if ! [ -d "opencv-2.4.10"]; then
+if ! [ -d "opencv-2.4.10" ]; then
   unzip OpenCV-2.4.10.zip
 fi
 rm OpenCV-2.4.10.zip


### PR DESCRIPTION
Script was failing with an error saying ```./opencv2_4_10.sh: line 28: [: missing `]'```