### PR TITLE
Fix bug in get latest opencv

### DIFF
--- a/Ubuntu/dependencies.sh
+++ b/Ubuntu/dependencies.sh
@@ -28,7 +28,9 @@ install_dependency libv4l-dev
 install_dependency python-dev
 install_dependency python-numpy
 install_dependency libtbb-dev
-install_dependency libqt4-dev
+install_dependency libqt5-dev
+install_dependency libqt5opengl5
+install_dependency libqt5opengl5-dev
 install_dependency libgtk2.0-dev
 install_dependency libfaac-dev
 install_dependency libmp3lame-dev

--- a/get_latest_version_download_file.sh
+++ b/get_latest_version_download_file.sh
@@ -2,7 +2,7 @@
 # 2014-01-29
 # Find the latest version and download file link from the OpenCV sourceforge page
 
-version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -m1 -o '\"[0-9](\.[0-9]+)+(-[-a-zA-Z0-9]+)?' | cut -c2-)"
+version="$(wget -q -O - http://sourceforge.net/projects/opencvlibrary/files/opencv-unix | egrep -o '\"[0-9](\.[0-9]+)+(-[-a-zA-Z0-9]+)?' | cut -c2- |sort -V -r -u |head -1)"
 downloadfilelist="opencv-$version.tar.gz opencv-$version.zip"
 downloadfile=
 for file in $downloadfilelist;


### PR DESCRIPTION
This will fix the bug to not search for last modified but for last version (3.1.0 instead of 2.4.13).