### PR TITLE
Removed unnecessary dependencies

### DIFF
--- a/Ubuntu/dependencies.sh
+++ b/Ubuntu/dependencies.sh
@@ -16,14 +16,14 @@ install_dependency pkg-config
 install_dependency yasm
 install_dependency libtiff5-dev
 install_dependency libjpeg-dev
-install_dependency libjasper-dev
+#install_dependency libjasper-dev
 install_dependency libavcodec-dev
 install_dependency libavformat-dev
 install_dependency libswscale-dev
 install_dependency libdc1394-22-dev
 install_dependency libxine2-dev
-install_dependency libgstreamer0.10-dev
-install_dependency libgstreamer-plugins-base0.10-dev
+#install_dependency libgstreamer0.10-dev
+#install_dependency libgstreamer-plugins-base0.10-dev
 install_dependency libv4l-dev
 install_dependency python-dev
 install_dependency python-numpy


### PR DESCRIPTION
Removed libjasper-dev, libgstreamer0.10-dev and libgstreamer-plugins-base0.10-dev. The apt manager was unable to locate these packages. Installation works without it.